### PR TITLE
cssh by instance and some typo fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* Add -i option to cssh to allow connecting by instance id
+* Fix some documentation and help text mistakes
+
 
 ## [0.0.26] - 2019-06-13
 

--- a/contrib/cssh
+++ b/contrib/cssh
@@ -2,9 +2,10 @@
 
 function usage() {
     cat <<EOF
-    Usage: $(basename ${0}) -p|--profile profile -n|--name instance-name [[-t|--tags key=value] ...]
+    Usage: $(basename ${0}) -p|--profile profile <-n|--name instance-name|-i|--instance instance-id> [[-t|--tags key=value] ...]
       profile       : as per ceres config file
       instance-name : full or part of the instance name (as per the Name tag)
+      instance-id   : full or part of the instance id
       tags          : one or more key=value pairs to filter
 
     When more than 1 instance matches the criteria, an error is returned.
@@ -17,6 +18,11 @@ while [[ ${#} > 0 ]]; do
         -p | --profile )
             shift
             PROFILE="${1}"
+            shift
+            ;;
+        -i | --instance)
+            shift
+            INSTANCEID="${1}"
             shift
             ;;
         -n | --name )
@@ -39,14 +45,24 @@ while [[ ${#} > 0 ]]; do
     esac
 done
 
-if [[ -z "${NAME}" || -z "${PROFILE}" ]]; then
+if [[ -z "${PROFILE}" ]]; then
+  usage
+fi
+if [[ -z "${NAME}" && -z "${INSTANCEID}" ]]; then
   usage
 fi
 
-F="State=running,Tags=Name=.*${NAME}.*"
-for t in ${TAGS}; do
-    F="${F}:${t}"
-done
+if [[ ! -z "${NAME}" ]]; then
+  F="State=running,Tags=Name=.*${NAME}.*"
+  for t in ${TAGS}; do
+      F="${F}:${t}"
+  done
+else
+  F="State=running,InstanceId=.*${INSTANCEID}.*"
+  for t in ${TAGS}; do
+      F="${F}:${t}"
+  done
+fi
 
 INSTANCEID=( $(ceres --profile ${PROFILE} instances list --output plain --output-options InstanceId --filter "${F}") ) 
 if [[ ! -z "${LIST}" ]]; then

--- a/docs/ceres.1.md
+++ b/docs/ceres.1.md
@@ -7,9 +7,9 @@ CenterDevice SRE (ceres) -- Ceres the goddess of agriculture, grain crops, ferti
 
 ceres [*options*] *MODULE*
 
-mhost --help
+ceres --help
 
-mhost --version
+ceres --version
 
 
 # DESCRIPTION
@@ -88,9 +88,6 @@ The *centerdevice* module interacts with a CenterDevice instance and offers basi
   -f, --filename *filename*
   : Filename for download; default is original document filename
 
-  -m, --mime-type *mime-type*
-  Sets the mime type of document; will be guest if not specified
-
   -P, --no-progress
   : Do not show progress
 
@@ -132,7 +129,7 @@ The *centerdevice* module interacts with a CenterDevice instance and offers basi
   : Sets filename of document different from original filename
 
   -m, --mime-type *mime-type*
-  : Sets the mime type of document; will be guest if not specified
+  : Sets the mime type of document; will be guessed if not specified
 
   -t, --tag *tags*...
   : Sets tag for document

--- a/docs/man1/ceres.1
+++ b/docs/man1/ceres.1
@@ -10,9 +10,9 @@ crops, fertility and motherly relationships.
 .PP
 ceres [\f[I]options\f[R]] \f[I]MODULE\f[R]
 .PP
-mhost \[en]help
+ceres \[en]help
 .PP
-mhost \[en]version
+ceres \[en]version
 .SH DESCRIPTION
 .PP
 ceres is a CLI tool for common SRE and ops tasks for CenterDevice.
@@ -93,9 +93,6 @@ Directory to download document to; default is current working directory
 .TP
 .B -f, \[en]filename \f[I]filename\f[R]
 Filename for download; default is original document filename
-.PP
--m, \[en]mime-type \f[I]mime-type\f[R] Sets the mime type of document;
-will be guest if not specified
 .TP
 .B -P, \[en]no-progress
 Do not show progress
@@ -139,7 +136,7 @@ Set collection id to add document to
 Sets filename of document different from original filename
 .TP
 .B -m, \[en]mime-type \f[I]mime-type\f[R]
-Sets the mime type of document; will be guest if not specified
+Sets the mime type of document; will be guessed if not specified
 .TP
 .B -t, \[en]tag \f[I]tags\f[R]\&...
 Sets tag for document

--- a/src/modules/centerdevice/upload.rs
+++ b/src/modules/centerdevice/upload.rs
@@ -25,7 +25,7 @@ impl Module for SubModule {
                 .long("mime-type")
                 .short("m")
                 .takes_value(true)
-                .help("Sets the mime type of document; will be guest if not specified"))
+                .help("Sets the mime type of document; will be guessed if not specified"))
             .arg(Arg::with_name("filename")
                 .long("filename")
                 .short("f")


### PR DESCRIPTION
Adds a new option to cssh to allow connections by instance id in addition to names.
Along the way, fix some language mistakes in the man page and help texts.